### PR TITLE
feat: break class list with quotes on new lines

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -64,7 +64,7 @@ module.exports = {
 
 The following options can be set to the mutiline rule:
 - `maxLen`: break classes as soon as the line length is longer than this (and join if the line is smaller)
-- `quotesOnNewLine`: put the quotes on different lines as the first and last class
+- `quotesOnNewLine`: put the quotes on different lines to the first and last class
 
 ```js
 module.exports = {

--- a/readme.md
+++ b/readme.md
@@ -62,7 +62,9 @@ module.exports = {
 }
 ```
 
-You can apply maxLen rule to tailwind classes by adding this to your `.eslintrc.js` file
+The following options can be set to the mutiline rule:
+- `maxLen`: break classes as soon as the line length is longer than this (and join if the line is smaller)
+- `quotesOnNewLine`: put the quotes on different lines as the first and last class
 
 ```js
 module.exports = {
@@ -72,7 +74,8 @@ module.exports = {
 	"@kalimahapps/tailwind/multiline": [
 		"warn",
 		{
-			"maxLen": 100
+			"maxLen": 100,
+      "quotesOnNewLine": true
 		}
 	]
 	}

--- a/rules/multiline.js
+++ b/rules/multiline.js
@@ -69,7 +69,7 @@ class TailwindMultiLine {
 	/* eslint complexity: ["warn", 8] */
 	joinClasses(classes) {
 		const { options } = this.context;
-		const { maxLen: maxLength = 80 } = options[0] || {};
+		const { maxLen: maxLength = 80, quotesOnNewLine = false } = options[0] || {};
 		const { loc: attributeLoc } = this.node;
 
 		// Get start of the line
@@ -115,7 +115,9 @@ class TailwindMultiLine {
 
 			// Repeat the spacing character to the length of the spacing
 			const spacingString = spacingCharacter.repeat(spacing.length + tabRepeat);
-			return `\n${spacingString}${classes.join(`\n${spacingString}`)}\n${spacingString}`;
+			return quotesOnNewLine
+				? `\n${spacingString}${classes.join(`\n${spacingString}`)}\n${spacingString}`
+				: classes.join(`\n${spacingString}`);
 		}
 
 		this.errorType = 'single-line';

--- a/rules/multiline.js
+++ b/rules/multiline.js
@@ -115,7 +115,7 @@ class TailwindMultiLine {
 
 			// Repeat the spacing character to the length of the spacing
 			const spacingString = spacingCharacter.repeat(spacing.length + tabRepeat);
-			return classes.join(`\n${spacingString}`);
+			return `\n${spacingString}${classes.join(`\n${spacingString}`)}\n${spacingString}`;
 		}
 
 		this.errorType = 'single-line';
@@ -140,14 +140,16 @@ class TailwindMultiLine {
 
 			// Check if item includes whitespace
 			const hasWhitespace = trimmedItem.match(/\s/u);
-			if (hasWhitespace === null) {
+			if (hasWhitespace === null && trimmedItem.length > 0) {
 				accumulator.push(trimmedItem);
 				return accumulator;
 			}
 
 			// Split the item by whitespace
 			const splitItem = trimmedItem.split(/\s+/u);
-			accumulator.push(...splitItem);
+			if (splitItem.length > 0 && splitItem[0].length > 0) {
+				accumulator.push(...splitItem);
+			}
 			return accumulator;
 		}, []);
 		return cleanClasses;

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -23,10 +23,12 @@ ruleTester.run('multiline', multlineRule, {
 		},
 		{
 			code: `<template>
-					<div class="text-red-500
+					<div class="
+						text-red-500
 						text-blue-500
 						text-green-500
-						text-yellow-500"
+						text-yellow-500
+						"
 					></div>
 				`,
 		},
@@ -37,11 +39,13 @@ ruleTester.run('multiline', multlineRule, {
                 <div class="text-red-500 text-blue-500 text-green-500 text-yellow-500 text-purple-500"></div>
                 </template>`,
 			output: `<template>
-                <div class="text-red-500
+                <div class="
+                    text-red-500
                     text-blue-500
                     text-green-500
                     text-yellow-500
-                    text-purple-500"></div>
+                    text-purple-500
+                    "></div>
                 </template>`,
 			errors: [{ message: 'Classes should be in multiple lines' }],
 		},
@@ -51,11 +55,13 @@ ruleTester.run('multiline', multlineRule, {
 					></div>
 				</template>`,
 			output: `<template><div
-					class="text-red-500
+					class="
+						text-red-500
 						text-blue-500
 						text-green-500
 						text-yellow-500
-						text-purple-500"
+						text-purple-500
+						"
 					></div>
 				</template>`,
 			errors: [{ message: 'Classes should be in multiple lines' }],
@@ -74,11 +80,13 @@ ruleTester.run('multiline', multlineRule, {
 						grid"
 				></div></template>`,
 			output: `<template>
-				<div class="text-red-500
+				<div class="
+					text-red-500
 					text-purple-500
 					grid-cols-2
 					bg-gray-200
-					grid"
+					grid
+					"
 				></div></template>`,
 			errors: [{ message: 'Classes should be in multiple lines' }],
 		},
@@ -87,7 +95,8 @@ ruleTester.run('multiline', multlineRule, {
 				<div class="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 dark:peer-focus:ring-blue-800 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-gray-600 peer-checked:bg-blue-600"></div>
 				</template>`,
 			output: `<template>
-				<div class="w-11
+				<div class="
+					w-11
 					h-6
 					bg-gray-200
 					peer-focus:outline-none
@@ -111,9 +120,32 @@ ruleTester.run('multiline', multlineRule, {
 					after:w-5
 					after:transition-all
 					dark:border-gray-600
-					peer-checked:bg-blue-600"></div>
+					peer-checked:bg-blue-600
+					"></div>
 				</template>`,
 			errors: [{ message: 'Classes should be in multiple lines' }],
+		},
+		{
+			code: `<template>
+					<div class="
+						text-red-500
+						text-blue-500
+
+						text-green-500
+						text-yellow-500
+						"
+					></div>
+				`,
+			output: `<template>
+					<div class="
+						text-red-500
+						text-blue-500
+						text-green-500
+						text-yellow-500
+						"
+					></div>
+				`,
+			errors: [{message: 'Classes should be in multiple lines'}],
 		},
 	],
 });

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -23,6 +23,15 @@ ruleTester.run('multiline', multlineRule, {
 		},
 		{
 			code: `<template>
+					<div class="text-red-500
+						text-blue-500
+						text-green-500
+						text-yellow-500"
+					></div>
+				`,
+		},
+		{
+			code: `<template>
 					<div class="
 						text-red-500
 						text-blue-500
@@ -31,6 +40,7 @@ ruleTester.run('multiline', multlineRule, {
 						"
 					></div>
 				`,
+			options: [{ quotesOnNewLine: true }],
 		},
 	],
 	invalid: [
@@ -39,13 +49,11 @@ ruleTester.run('multiline', multlineRule, {
                 <div class="text-red-500 text-blue-500 text-green-500 text-yellow-500 text-purple-500"></div>
                 </template>`,
 			output: `<template>
-                <div class="
-                    text-red-500
+                <div class="text-red-500
                     text-blue-500
                     text-green-500
                     text-yellow-500
-                    text-purple-500
-                    "></div>
+                    text-purple-500"></div>
                 </template>`,
 			errors: [{ message: 'Classes should be in multiple lines' }],
 		},
@@ -55,13 +63,11 @@ ruleTester.run('multiline', multlineRule, {
 					></div>
 				</template>`,
 			output: `<template><div
-					class="
-						text-red-500
+					class="text-red-500
 						text-blue-500
 						text-green-500
 						text-yellow-500
-						text-purple-500
-						"
+						text-purple-500"
 					></div>
 				</template>`,
 			errors: [{ message: 'Classes should be in multiple lines' }],
@@ -80,13 +86,11 @@ ruleTester.run('multiline', multlineRule, {
 						grid"
 				></div></template>`,
 			output: `<template>
-				<div class="
-					text-red-500
+				<div class="text-red-500
 					text-purple-500
 					grid-cols-2
 					bg-gray-200
-					grid
-					"
+					grid"
 				></div></template>`,
 			errors: [{ message: 'Classes should be in multiple lines' }],
 		},
@@ -95,8 +99,7 @@ ruleTester.run('multiline', multlineRule, {
 				<div class="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 dark:peer-focus:ring-blue-800 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-gray-600 peer-checked:bg-blue-600"></div>
 				</template>`,
 			output: `<template>
-				<div class="
-					w-11
+				<div class="w-11
 					h-6
 					bg-gray-200
 					peer-focus:outline-none
@@ -120,8 +123,7 @@ ruleTester.run('multiline', multlineRule, {
 					after:w-5
 					after:transition-all
 					dark:border-gray-600
-					peer-checked:bg-blue-600
-					"></div>
+					peer-checked:bg-blue-600"></div>
 				</template>`,
 			errors: [{ message: 'Classes should be in multiple lines' }],
 		},
@@ -130,10 +132,26 @@ ruleTester.run('multiline', multlineRule, {
 					<div class="
 						text-red-500
 						text-blue-500
-
 						text-green-500
 						text-yellow-500
 						"
+					></div>
+				`,
+			output: `<template>
+					<div class="text-red-500
+						text-blue-500
+						text-green-500
+						text-yellow-500"
+					></div>
+				`,
+			errors: [{message: 'Classes should be in multiple lines'}],
+		},
+		{
+			code: `<template>
+					<div class="text-red-500
+						text-blue-500
+						text-green-500
+						text-yellow-500"
 					></div>
 				`,
 			output: `<template>
@@ -145,6 +163,7 @@ ruleTester.run('multiline', multlineRule, {
 						"
 					></div>
 				`,
+			options: [{quotesOnNewLine: true}],
 			errors: [{message: 'Classes should be in multiple lines'}],
 		},
 	],


### PR DESCRIPTION
I think it is cleaner, when the classes are all in their own line. So the quotes are on different lines than the classes.
(This also makes it easier to yank/paste classes in vim, for example.)

Before:

```html
<template>
         <div class="text-red-500
                 text-blue-500
                 text-green-500
                 text-yellow-500"
         ></div>
</template>
```

After:

```html
<template>
         <div class="
                 text-red-500
                 text-blue-500
                 text-green-500
                 text-yellow-500
                 "
         ></div>
</template>
```